### PR TITLE
Remove NUnit and use Xunit instead

### DIFF
--- a/tests/Couchbase.Extensions.Caching.IntegrationTests/CacheServiceExtensionTests.cs
+++ b/tests/Couchbase.Extensions.Caching.IntegrationTests/CacheServiceExtensionTests.cs
@@ -1,21 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Linq;
 using Couchbase.Extensions.Caching.IntegrationTests.Infrastructure;
 using Couchbase.Extensions.DependencyInjection;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace Couchbase.Extensions.Caching.IntegrationTests
 {
-    [TestFixture]
     public class CacheServiceExtensionTests
     {
-        [Ignore("Temporarily skip.")]
-        [Test]
+        [Fact(Skip = "Temporarily skip.")]
         public void AddDistributedCouchbaseCache_ReplacesPreviouslyUserRegisteredServices()
         {
             // Arrange
@@ -34,8 +29,8 @@ namespace Couchbase.Extensions.Caching.IntegrationTests
             var distributedCache = services.FirstOrDefault(desc => desc.ServiceType == typeof(IDistributedCache));
 
             Assert.NotNull(distributedCache);
-            Assert.AreEqual(ServiceLifetime.Scoped, distributedCache.Lifetime);
-            Assert.IsInstanceOf<CouchbaseCache>(serviceProvider.GetRequiredService<IDistributedCache>());
+            Assert.Equal(ServiceLifetime.Scoped, distributedCache.Lifetime);
+            Assert.IsAssignableFrom<CouchbaseCache>(serviceProvider.GetRequiredService<IDistributedCache>());
         }
     }
 }

--- a/tests/Couchbase.Extensions.Caching.IntegrationTests/project.json
+++ b/tests/Couchbase.Extensions.Caching.IntegrationTests/project.json
@@ -7,18 +7,18 @@
     }
   },
 
-  "testRunner": "nunit",
+  "testRunner": "xunit",
 
   "dependencies": {
     "Couchbase.Extensions.Caching": "1.0.0-*",
-    "dotnet-test-nunit": "3.4.0-beta-3",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.Extensions.Caching.Abstractions": "1.1.2",
     "Microsoft.Extensions.Configuration": "1.1.2",
     "Microsoft.Extensions.Configuration.Binder": "1.1.2",
     "Microsoft.Extensions.Configuration.Json": "1.1.2",
     "Microsoft.NETCore.App": "1.1.2",
     "Moq": "4.6.38-alpha",
-    "NUnit": "3.6.1"
+    "xunit": "2.2.0-beta4-build3444"
   },
 
   "frameworks": {

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CacheServiceExtensionTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CacheServiceExtensionTests.cs
@@ -2,18 +2,14 @@
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
-using NUnit.Framework;
 using System.Linq;
-using Couchbase.Configuration.Client;
-using Couchbase.Core;
-using Couchbase.Extensions.DependencyInjection;
+using Xunit;
 
 namespace Couchbase.Extensions.Caching.UnitTests
 {
-    [TestFixture]
     public class CacheServiceExtensionTests
     {
-        [Test]
+        [Fact]
         public void AddDistributedCouchbaseCache_RegistersDistributedCacheAsSingleton()
         {
             // Arrange
@@ -26,15 +22,15 @@ namespace Couchbase.Extensions.Caching.UnitTests
             var distributedCache = services.FirstOrDefault(desc => desc.ServiceType == typeof(IDistributedCache));
 
             Assert.NotNull(distributedCache);
-            Assert.AreEqual(ServiceLifetime.Singleton, distributedCache.Lifetime);
+            Assert.Equal(ServiceLifetime.Singleton, distributedCache.Lifetime);
         }
 
-        [Test]
+        [Fact]
         public void AddDistributedCouchbaseCache_Allows_Chaining()
         {
             var services = new ServiceCollection();
 
-            Assert.AreSame(services, services.AddDistributedCouchbaseCache("bucketName", _ => { }));
+            Assert.Same(services, services.AddDistributedCouchbaseCache("bucketName", _ => { }));
         }
     }
 }

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheExtensionTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheExtensionTests.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Distributed;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace Couchbase.Extensions.Caching.UnitTests
 {
-    [TestFixture]
     public class CouchbaseCacheExtensionTests
     {
-        [Test]
+        [Fact]
         public void Set_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -18,17 +18,17 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Set(null, new byte[0], new DistributedCacheEntryOptions()));
         }
 
-        [Test]
-        public void SetAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task SetAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], new DistributedCacheEntryOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], new DistributedCacheEntryOptions()));
         }
 
-        [Test]
+        [Fact]
         public void Get_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -38,17 +38,17 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Get(null, new DistributedCacheEntryOptions()));
         }
 
-        [Test]
-        public void GetAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task GetAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync(null, new DistributedCacheEntryOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync(null, new DistributedCacheEntryOptions()));
         }
 
-        [Test]
+        [Fact]
         public void Get_Generic_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -58,14 +58,14 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Get<Poco>(null, new DistributedCacheEntryOptions()));
         }
 
-        [Test]
-        public void GetAsynct_Generic_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task GetAsynct_Generic_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync<Poco>(null, new DistributedCacheEntryOptions()));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync<Poco>(null, new DistributedCacheEntryOptions()));
         }
 
         public class Poco

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Couchbase.Core;
 using Moq;
-using NUnit.Framework;
+using Xunit;
 
 namespace Couchbase.Extensions.Caching.UnitTests
 {
-    [TestFixture]
     public class CouchbaseCacheTests
     {
-        [Test]
+        [Fact]
         public void Set_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -18,17 +18,17 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Set(null, new byte[0], null));
         }
 
-        [Test]
-        public void SetAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task SetAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], null));
         }
 
-        [Test]
+        [Fact]
         public void Get_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -38,17 +38,17 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Get(null));
         }
 
-        [Test]
-        public void GetAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task GetAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.GetAsync(null));
         }
 
-        [Test]
+        [Fact]
         public void Refresh_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -58,17 +58,17 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Refresh(null));
         }
 
-        [Test]
-        public void RefreshAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task RefreshAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.RefreshAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.RefreshAsync(null));
         }
 
-        [Test]
+        [Fact]
         public void Remove_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
@@ -78,17 +78,18 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Remove(null));
         }
 
-        [Test]
-        public void RemoveAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task RemoveAsync_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync< ArgumentNullException>(async () => await cache.RemoveAsync(null));
+            await Assert.ThrowsAsync< ArgumentNullException>(async () => await cache.RemoveAsync(null));
         }
 
-        [Test] public void Set_WhenValueIsNull_ThrowArgumentNullException()
+        [Fact]
+        public void Set_WhenValueIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
@@ -97,14 +98,14 @@ namespace Couchbase.Extensions.Caching.UnitTests
             Assert.Throws<ArgumentNullException>(() => cache.Set(null, new byte[0], null));
         }
 
-        [Test]
-        public void SetAsync_WhenValueIsNull_ThrowArgumentNullException()
+        [Fact]
+        public async Task SetAsync_WhenValueIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheBucketProvider>();
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], null));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, new byte[0], null));
         }
     }
 }

--- a/tests/Couchbase.Extensions.Caching.UnitTests/project.json
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/project.json
@@ -7,12 +7,13 @@
     }
   },
 
-  "testRunner": "nunit",
+  "testRunner": "xunit",
 
   "dependencies": {
     "Couchbase.Extensions.Caching": "1.0.0-*",
+    "Couchbase.Extensions.DependencyInjection": "1.0.0-*",
     "Couchbase.Extensions.Session": "1.0.0-*",
-    "dotnet-test-nunit": "3.4.0-beta-3",
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
     "Microsoft.AspNetCore.Session": "1.1.2",
     "Microsoft.AspNetCore.TestHost": "1.1.2",
     "Microsoft.Extensions.Caching.Memory": "1.1.2",
@@ -20,7 +21,7 @@
     "Microsoft.Extensions.DependencyInjection.Abstractions": "1.1.1",
     "Microsoft.NETCore.App": "1.1.2",
     "Moq": "4.6.38-alpha",
-    "NUnit": "3.6.1"
+    "xunit": "2.2.0-beta4-build3444"
   },
 
   "frameworks": {


### PR DESCRIPTION
Motivation
----------
For consistency use Xunit instead of NUnit for testing in all projects.

Modifications
-------------
 - Replace NUnit dependency with XUnit
 - Update unit tests using NUnit to use Xunit attributes.

Result
------
All test projects are noew using Xunit.