### PR TITLE
Provide automatic DNS discovery to simplify configuration

### DIFF
--- a/src/Couchbase.Extensions.DnsDiscovery/ICouchbaseDnsLookup.cs
+++ b/src/Couchbase.Extensions.DnsDiscovery/ICouchbaseDnsLookup.cs
@@ -4,6 +4,19 @@ namespace Couchbase.Extensions.DnsDiscovery
 {
     public interface ICouchbaseDnsLookup
     {
+        /// <summary>
+        /// Attempts to resolve DNS SRV records from the domain listed in
+        /// "couchbase://domain.name" entries in the <see cref="CouchbaseClientDefinition.Servers"/>
+        /// collection.
+        /// </summary>
+        /// <param name="clientDefinition">The client definition to update.</param>
+        void Apply(CouchbaseClientDefinition clientDefinition);
+
+        /// <summary>
+        /// Attempts to resolve DNS SRV records from the provided domain name.
+        /// </summary>
+        /// <param name="clientDefinition">The client definition to update.</param>
+        /// <param name="recordName">Domain name to resolve.</param>
         void Apply(CouchbaseClientDefinition clientDefinition, string recordName);
     }
 }

--- a/src/Couchbase.Extensions.DnsDiscovery/ServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.DnsDiscovery/ServiceCollectionExtensions.cs
@@ -13,6 +13,38 @@ namespace Couchbase.Extensions.DnsDiscovery
     public static class ServiceCollectionExtensions
     {
         /// <summary>
+        /// Add DNS SRV resolution for Couchbase servers.<see cref="IServiceCollection"/>.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/>.</param>
+        /// <returns>The <see cref="IServiceCollection"/>.</returns>
+        /// <remarks>
+        /// This method should be called after adding any other Couchbase configuration
+        /// to the service provider.  It expects "couchbase://domain.name" to be in the list of
+        /// configured Couchbase servers, and will attempt DNS SRV resolution on the provided
+        /// domain name.  If not found, it will assume that the provided servers are direct
+        /// access and do not require DNS SRV resolution.
+        /// </remarks>
+        public static IServiceCollection AddCouchbaseDnsDiscovery(this IServiceCollection services)
+        {
+            // Register CouchbaseDnsLookup
+            services.TryAddTransient<ILookupClientAdapter, LookupClientAdapter>();
+            services.TryAddTransient<ICouchbaseDnsLookup, CouchbaseDnsLookup>();
+
+            // Register the action to alter CouchbaseClientDefinition options
+            return services.AddTransient<IConfigureOptions<CouchbaseClientDefinition>>(serviceProvider =>
+            {
+                // Get the ICouchbaseDnsLookup implementation
+                var lookup = serviceProvider.GetRequiredService<ICouchbaseDnsLookup>();
+
+                // Return action that calls Apply on the ICouchbaseDnsLookup implementation
+                return new ConfigureOptions<CouchbaseClientDefinition>(clientDefinition =>
+                {
+                    lookup.Apply(clientDefinition);
+                });
+            });
+        }
+
+        /// <summary>
         /// Add Couchbase dependencies to the <see cref="IServiceCollection"/>.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>


### PR DESCRIPTION
Motivation
----------
Other Couchbase SDKs support automatically discovering DNS SRV records
based on the passed couchbase:// URL.  Bring this extension into
alignment with that behavior.

Modifications
-------------
Provide an additional registration endpoint that doesn't take a record
name.  When this endpoint is used, assume that the client definition
may contain a URI which can be used for DNS discovery.  Ignore failures
and leave the definition server list unmodified.

Results
-------
Fully backwards compatible with the previous behavior, but now much
easier to configure and more consistent with other Couchbase SDKs.