### PR TITLE
DNS SRV support for connection strings

### DIFF
--- a/docs/dns-srv.md
+++ b/docs/dns-srv.md
@@ -2,7 +2,8 @@
 
 A .Net Core compatible DNS SRV mechanism for discovering a Couchbase cluster dynamically.
 
-## Getting Started ##
+## Getting Started
+
 Assuming you have an [installation of Couchbase Server](https://developer.couchbase.com/documentation/server/4.5/getting-started/installing.html) and Visual Studio (examples with VSCODE forthcoming), do the following:
 
 - Create a .NET Core Web Application using Visual Studio or VsCodeor CIL
@@ -13,6 +14,7 @@ Assuming you have an [installation of Couchbase Server](https://developer.couchb
 To use, call `AddCouchbaseDnsDiscovery` during the service registration process, usually in your `Startup` class.  You may choose whether or not to add this step based on the environment.  Be sure to add the basic Couchbase configuration first.
 
 ```csharp
+
 public class Startup
 {
     public Startup(IHostingEnvironment env)
@@ -41,14 +43,13 @@ public class Startup
 ```
 
 Example configuration file:
+
 ```json
 {
     "Couchbase": {
         "Username": "Administrator",
         "Password": "Password",
-        "Servers": [
-            "couchbase://services.local/"
-        ]
+        "ConnectionString": "couchbase://services.local"
     }
 }
 ```
@@ -56,11 +57,11 @@ Example configuration file:
 The above configuration will perform a DNS SRV query for `_couchbase._tcp.services.local`, based on the single entry in the Servers section of the configuration.  The results will be used to replace the Servers list in the Couchbase client configuration.
 
 The following rules will be applied:
-1. There must be only one URI in the Servers collection
-2. The URI must use either the "couchbase://" or "couchbases://" scheme
-3. The URI must not have a port number
-4. If these rules aren't matched, or if no DNS SRV records is found, then the client will fallback to directly connecting to the listed URIs
 
-Note that only the servers with the highest priority in the DNS SRV response will be used.  For example, if the response returns 2 servers with a priority of 10 and 2 different servers with a priority of 20, the first set will be used to initialize the cluster.  SRV record failover is not supported.
+1. If using ConnectionString, there must be only one server listed in the string
+2. If using the Servers collection, there must be only one URI in the collection
+3. The URI must use either the "couchbase://" or "couchbases://" scheme
+4. The URI must not have a port number
+5. If these rules aren't matched, or if no DNS SRV records is found, then the client will fallback to directly connecting to the listed servers
 
-Additionally, due to the nature of Couchbase clusters, the weight fields in the DNS SRV records are ignored.  However, the port is used and should normally be set to 8091.
+Due to the nature of Couchbase clusters, the priority and weight fields in the DNS SRV records are ignored.  However, the port is used and should normally be set to 11210 for _couchbase and 11207 for _couchbases.

--- a/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
+++ b/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.9" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />

--- a/src/Couchbase.Extensions.DependencyInjection/Couchbase.Extensions.DependencyInjection.csproj
+++ b/src/Couchbase.Extensions.DependencyInjection/Couchbase.Extensions.DependencyInjection.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.1" />

--- a/src/Couchbase.Extensions.DnsDiscovery/Couchbase.Extensions.DnsDiscovery.csproj
+++ b/src/Couchbase.Extensions.DnsDiscovery/Couchbase.Extensions.DnsDiscovery.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="DnsClient" Version="1.0.1" />
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="1.1.2" />
   </ItemGroup>

--- a/src/Couchbase.Extensions.Encryption/Couchbase.Extensions.Encryption.csproj
+++ b/src/Couchbase.Extensions.Encryption/Couchbase.Extensions.Encryption.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.9" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/tests/Couchbase.Extensions.DependencyInjection.IntegrationTests/Couchbase.Extensions.DependencyInjection.IntegrationTests.csproj
+++ b/tests/Couchbase.Extensions.DependencyInjection.IntegrationTests/Couchbase.Extensions.DependencyInjection.IntegrationTests.csproj
@@ -30,4 +30,8 @@
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Couchbase.Extensions.DependencyInjection.UnitTests/Couchbase.Extensions.DependencyInjection.UnitTests.csproj
+++ b/tests/Couchbase.Extensions.DependencyInjection.UnitTests/Couchbase.Extensions.DependencyInjection.UnitTests.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/tests/Couchbase.Extensions.DnsDiscovery.UnitTests/Couchbase.Extensions.DnsDiscovery.UnitTests.csproj
+++ b/tests/Couchbase.Extensions.DnsDiscovery.UnitTests/Couchbase.Extensions.DnsDiscovery.UnitTests.csproj
@@ -25,4 +25,8 @@
     <PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
 </Project>

--- a/tests/TestApp/Startup.cs
+++ b/tests/TestApp/Startup.cs
@@ -32,12 +32,8 @@ namespace TestApp
             // Register Couchbase with configuration section
             services
                 .AddCouchbase(Configuration.GetSection("Couchbase"))
+                .AddCouchbaseDnsDiscovery()
                 .AddCouchbaseBucket<ITravelSampleBucketProvider>("travel-sample");
-
-            if (Environment.IsProduction())
-            {
-                services.AddCouchbaseDnsDiscovery("_couchbase._tcp.services.local");
-            }
 
             services.AddMvc();
         }

--- a/tests/TestApp/TestApp.csproj
+++ b/tests/TestApp/TestApp.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.5.5" />
+    <PackageReference Include="CouchbaseNetClient" Version="2.5.9" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" />

--- a/tests/TestApp/appsettings.json
+++ b/tests/TestApp/appsettings.json
@@ -14,9 +14,7 @@
   "Couchbase": {
     "Username": "Administrator",
     "Password":  "password",
-    "Servers": [
-      "http://localhost:8091/"
-    ],
+    "ConnectionString": "couchbase://localhost",
     "Buckets": [
       {
         "Name": "travel-sample"


### PR DESCRIPTION
Motivation
----------
Support the DNS SRV portion of the couchbase:// connection string
specification as transparently as possible.

Modifications
-------------
Upgrade Couchbase SDK to 2.5.9, which includes couchbase:// connection
string support.

Detect the use of the connection string, and when compatible
automatically perform DNS SRV lookups.  Replace the connection string
with the list of servers, if found.

Ignore the priority on the DNS SRV entries to be consitent with the
specification.

Results
-------
So long as .AddCouchbaseDnsDiscovery() is applied to the DI container,
DNS SRV discovery following the Couchbase specification
https://github.com/couchbaselabs/sdk-rfcs/blob/master/rfc/0011-connection-string.md#srv-records
is performed automatically.

If using the legacy .AddCouchbaseDnsDiscovery(recordName) approach,
priority is still applied to maintain backwards compatibility.