### PR TITLE
Updated Absolute Property Logic And Adjusted Timespans (45)

### DIFF
--- a/src/Couchbase.Extensions.Caching/CouchbaseCacheExtensions.cs
+++ b/src/Couchbase.Extensions.Caching/CouchbaseCacheExtensions.cs
@@ -211,11 +211,11 @@ namespace Couchbase.Extensions.Caching
             }
             if (itemOptions?.AbsoluteExpirationRelativeToNow != null)
             {
-                return new TimeSpan(DateTime.UtcNow.Add(itemOptions.AbsoluteExpirationRelativeToNow.Value).Ticks);
+                return itemOptions.AbsoluteExpirationRelativeToNow.Value;
             }
             if (itemOptions?.AbsoluteExpiration != null)
             {
-                return TimeSpan.FromTicks(itemOptions.AbsoluteExpiration.Value.Ticks);
+                return TimeSpan.FromTicks(itemOptions.AbsoluteExpiration.Value.Ticks - DateTime.UtcNow.Ticks);
             }
             return couchbaseCache.Options.Value.LifeSpan ?? CouchbaseCache.InfiniteLifetime;
         }

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheExtensionTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheExtensionTests.cs
@@ -84,13 +84,18 @@ namespace Couchbase.Extensions.Caching.UnitTests
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            var absoluteExpiration = DateTime.UtcNow.AddDays(1);
+            var now = DateTime.UtcNow;
+
+            var timerIncrement = 1;
+
+            var absoluteExpiration = now.AddDays(timerIncrement);
+
             var result = CouchbaseCacheExtensions.GetLifetime(cache, new DistributedCacheEntryOptions
             {
                 AbsoluteExpiration = new DateTimeOffset(absoluteExpiration)
             });
 
-            Assert.Equal(new DateTime(result.Ticks), absoluteExpiration);
+            Assert.Equal(TimeSpan.FromDays(timerIncrement).Ticks, (long)Math.Round((double)result.Ticks / 1000000000) * 1000000000);
         }
 
         [Fact]
@@ -100,15 +105,18 @@ namespace Couchbase.Extensions.Caching.UnitTests
 
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
-            var absoluteExpirationRelativeToNow = TimeSpan.FromDays(1);
+            var now = DateTime.UtcNow;
+
+            var timerIncrement = 15;
+
+            var absoluteExpirationRelativeToNow = TimeSpan.FromMinutes(timerIncrement);
+
             var result = CouchbaseCacheExtensions.GetLifetime(cache, new DistributedCacheEntryOptions
             {
                 AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow
             });
-
-            output.WriteLine(new DateTime(result.Ticks).ToShortDateString());
-            Assert.Equal(new DateTime(result.Ticks).ToShortDateString(),
-                DateTime.UtcNow.AddTicks(absoluteExpirationRelativeToNow.Ticks).ToShortDateString());
+            
+            Assert.Equal(absoluteExpirationRelativeToNow.Ticks, (long)Math.Round((double)result.Ticks/1000000000)*1000000000);
         }
 
         [Fact]


### PR DESCRIPTION
Motivation
----
Prior, there was an issue where documents cached using the absolute properties were seemingly instantly deleted from the bucket

Modifications
----
Adjusted GetLifeTime logic for the Absolute properties to return timespans relative to utc time:
* AbsoluteExpirationRelativeToNow will return the timespan length that was passed to it (so passing timespan of 15 will return a timespan of 15)
* AbsoluteExpiration will return a timespan whose length is equal to the AbsoluteExpiration date minus the UTC now date

Result
----
Documents saved via the cache when using the absolute properties should no longer be instantly deleted