### PR TITLE
Uses async await instead of eliding

### DIFF
--- a/src/Couchbase.Extensions.Caching/CouchbaseCache.cs
+++ b/src/Couchbase.Extensions.Caching/CouchbaseCache.cs
@@ -112,7 +112,7 @@ namespace Couchbase.Extensions.Caching
         /// <param name="value">An array of bytes representing the item.</param>
         /// <param name="options">The <see cref="DistributedCacheEntryOptions"/> for the item; note that only sliding expiration is currently supported.</param>
         /// <param name="token">The <see cref="CancellationToken"/> for the operation.</param>
-        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
+        public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
             CancellationToken token = new CancellationToken())
         {
             token.ThrowIfCancellationRequested();
@@ -125,7 +125,7 @@ namespace Couchbase.Extensions.Caching
                 throw new ArgumentNullException(nameof(value));
             }
 
-            return Bucket.UpsertAsync(key, value, GetLifetime(options));
+            await Bucket.UpsertAsync(key, value, GetLifetime(options)).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Stumbled upon one member in the cache that elides the call instead of using await and async as the other members do. Not really sure if it's by design or if it should be consistent.