### PR TITLE
Upgrade locks to SDK 3.x

### DIFF
--- a/docs/locks.md
+++ b/docs/locks.md
@@ -4,7 +4,7 @@ A system for managing distributed mutexs backed by Couchbase. This can prevent m
 
 ## Getting Started
 
-Assuming you have an [installation of Couchbase Server](https://developer.couchbase.com/documentation/server/4.5/getting-started/installing.html) and Visual Studio  VSCODE forthcoming), do the following:
+Assuming you have an [installation of Couchbase Server](https://docs.couchbase.com/server/current/introduction/intro.html) and Visual Studio  VSCODE forthcoming), do the following:
 
 - Install the package from [NuGet](https://www.nuget.org/packages/Couchbase.Extensions.Locks/) or build from source and add a reference.
 
@@ -34,10 +34,11 @@ public class MyController : Controller
 
     public IActionResult Index()
     {
-        var bucket = _bucketProvider.GetBucket("default");
+        var bucket = await _bucketProvider.GetBucketAsync("default");
+        var collection = bucket.DefaultCollection();
 
         try {
-            using (var mutex = await bucket.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(15)))
+            using (var mutex = await collection.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(15)))
             {
                 // This lock will be held for the shorter of the using statement lifespan or 15 seconds
             }
@@ -70,10 +71,11 @@ public class MyController : Controller
 
     public IActionResult Index()
     {
-        var bucket = _bucketProvider.GetBucket("default");
+        var bucket = await _bucketProvider.GetBucketAsync("default");
+        var collection = bucket.DefaultCollection();
 
         try {
-            using (var mutex = await bucket.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(15)))
+            using (var mutex = await collection.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(15)))
             {
                 while (true)
                 {
@@ -118,10 +120,11 @@ public class MyController : Controller
 
     public IActionResult Index()
     {
-        var bucket = _bucketProvider.GetBucket("default");
+        var bucket = await _bucketProvider.GetBucketAsync("default");
+        var collection = bucket.DefaultCollection();
 
         try {
-            using (var mutex = await bucket.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(10)))
+            using (var mutex = await collection.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(10)))
             {
                 mutex.AutoRenew(TimeSpan.FromSeconds(5), TimeSpan.FromMinutes(1));
 
@@ -168,13 +171,14 @@ public class MyController : Controller
 
     public IActionResult Index()
     {
-        var bucket = _bucketProvider.GetBucket("default");
+        var bucket = await _bucketProvider.GetBucketAsync("default");
+        var collection = bucket.DefaultCollection();
 
         try {
             // Wrapping the call in LockPolicy.ExecuteAsync applies the wait and retry logic
             // for any CouchbaseLockUnavailableException.  All other exceptions throw immediately.
             using (var mutex = await LockPolicy.ExecuteAsync(
-                () => bucket.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(10))))
+                () => collection.RequestMutexAsync("my-lock-name", TimeSpan.FromSeconds(10))))
             {
                 // Do work here
             }

--- a/example/Couchbase.Extensions.Locks.Example/Couchbase.Extensions.Locks.Example.csproj
+++ b/example/Couchbase.Extensions.Locks.Example/Couchbase.Extensions.Locks.Example.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.4" />
-    <PackageReference Include="Polly" Version="6.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.10" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/Couchbase.Extensions.Locks.Example/Properties/launchSettings.json
+++ b/example/Couchbase.Extensions.Locks.Example/Properties/launchSettings.json
@@ -1,21 +1,5 @@
 {
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:62314/",
-      "sslPort": 44373
-    }
-  },
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "https://localhost:44373/",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "Couchbase.Extensions.Locks.Example": {
       "commandName": "Project",
       "launchBrowser": true,

--- a/example/Couchbase.Extensions.Locks.Example/Startup.cs
+++ b/example/Couchbase.Extensions.Locks.Example/Startup.cs
@@ -28,7 +28,7 @@ namespace Couchbase.Extensions.Locks.Example
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env,  IApplicationLifetime applicationLifetime)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             if (env.IsDevelopment())
             {
@@ -48,11 +48,6 @@ namespace Couchbase.Extensions.Locks.Example
                 routes.MapRoute(
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
-            });
-
-            applicationLifetime.ApplicationStopped.Register(() =>
-            {
-                app.ApplicationServices.GetRequiredService<ICouchbaseLifetimeService>().Close();
             });
         }
     }

--- a/example/Couchbase.Extensions.Locks.Example/Views/Shared/Error.cshtml
+++ b/example/Couchbase.Extensions.Locks.Example/Views/Shared/Error.cshtml
@@ -1,4 +1,4 @@
-﻿@model ErrorViewModel
+﻿@model Couchbase.Extensions.Locks.Example.Models.ErrorViewModel
 @{
     ViewData["Title"] = "Error";
 }

--- a/example/Couchbase.Extensions.Locks.Example/appsettings.json
+++ b/example/Couchbase.Extensions.Locks.Example/appsettings.json
@@ -7,14 +7,7 @@
   },
   "Couchbase": {
     "Username": "Administrator",
-    "Password" : "password",
-    "Servers": [
-      "http://localhost:8091"
-    ],
-    "Buckets": [
-      {
-        "Name": "default"
-      }
-    ]
+    "Password": "password",
+    "ConnectionString": "couchbase://localhost"
   }
 }

--- a/src/Couchbase.Extensions.Locks/Couchbase.Extensions.Locks.csproj
+++ b/src/Couchbase.Extensions.Locks/Couchbase.Extensions.Locks.csproj
@@ -11,19 +11,20 @@
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/couchbaselabs/Couchbase.Extensions</RepositoryUrl>
-    <NetStandardImplicitPackageVersion>2.0.1</NetStandardImplicitPackageVersion>
-    <AssetTargetFallback>$(AssetTargetFallback);dnxcore50</AssetTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
 
-		<VersionPrefix>1.0.0</VersionPrefix>
+    <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
+
+    <VersionPrefix>2.0.0</VersionPrefix>
     <VersionSuffix>local-$([System.DateTime]::UtcNow.ToString('yyyyMMddHHmm'))</VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="2.6.0" />
-    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="2.0.2" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.0.5" />
+    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.0.4.811" />
   </ItemGroup>
 
 </Project>

--- a/src/Couchbase.Extensions.Locks/CouchbaseLockUnavailableException.cs
+++ b/src/Couchbase.Extensions.Locks/CouchbaseLockUnavailableException.cs
@@ -13,9 +13,9 @@ namespace Couchbase.Extensions.Locks
         public string Name { get; set; }
 
         /// <summary>
-        /// Requested lock holder.
+        /// Current holder of the lock, if known.
         /// </summary>
-        public string Holder { get; set; }
+        public string? Holder { get; set; }
 
         /// <summary>
         /// Creates a new CouchbaseLockUnavailableException.
@@ -24,6 +24,7 @@ namespace Couchbase.Extensions.Locks
         public CouchbaseLockUnavailableException(string name)
             : base($"Lock '{name}' is currently unavailable.")
         {
+            Name = name;
         }
     }
 }

--- a/src/Couchbase.Extensions.Locks/ICouchbaseMutex.cs
+++ b/src/Couchbase.Extensions.Locks/ICouchbaseMutex.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Couchbase.Extensions.Locks
@@ -28,10 +29,11 @@ namespace Couchbase.Extensions.Locks
         /// If auto renewal is in progress, future renewals will use the new expiration duration.
         /// </remarks>
         /// <param name="expiration">Length of time to renew the lock.</param>
+        /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>Task.</returns>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="expiration"/> is not positive.</exception>
         /// <exception cref="CouchbaseLockUnavailableException">The lock already expired and was taken.</exception>
-        Task Renew(TimeSpan expiration);
+        Task Renew(TimeSpan expiration, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Enables automatic lock renewal until the lock is disposed, using the previously set expiration.

--- a/src/Couchbase.Extensions.Locks/Internal/LockDocument.cs
+++ b/src/Couchbase.Extensions.Locks/Internal/LockDocument.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Couchbase.Core.Serialization;
+using Couchbase.Core.IO.Serializers;
 using Newtonsoft.Json;
 
 namespace Couchbase.Extensions.Locks.Internal
@@ -9,10 +9,10 @@ namespace Couchbase.Extensions.Locks.Internal
         private const string LockPrefix = "__lock_";
 
         [JsonProperty(PropertyName = "name")]
-        public string Name { get; set; }
+        public string? Name { get; set; }
 
         [JsonProperty(PropertyName = "holder")]
-        public string Holder { get; set; }
+        public string? Holder { get; set; }
 
         [JsonConverter(typeof(UnixMillisecondsConverter))]
         [JsonProperty(PropertyName = "requestedDateTime")]

--- a/tests/Couchbase.Extensions.Locks.UnitTests/Couchbase.Extensions.Locks.UnitTests.csproj
+++ b/tests/Couchbase.Extensions.Locks.UnitTests/Couchbase.Extensions.Locks.UnitTests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Moq" Version="4.14.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Couchbase.Extensions.Locks.UnitTests/Internal/CouchbaseMutexTests.cs
+++ b/tests/Couchbase.Extensions.Locks.UnitTests/Internal/CouchbaseMutexTests.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using Couchbase.Core;
 using Couchbase.Extensions.Locks.Internal;
+using Couchbase.KeyValue;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -14,20 +14,20 @@ namespace Couchbase.Extensions.Locks.UnitTests.Internal
 
         public static IEnumerable<object[]> CtorNullParameters()
         {
-            var bucket = new Mock<IBucket>().Object;
+            var collection = Mock.Of<ICouchbaseCollection>();
 
-            yield return new object[] {null, "name", "holder", "bucket"};
-            yield return new object[] {bucket, null, "holder", "name"};
-            yield return new object[] {bucket, "name", null, "holder"};
+            yield return new object[] {null, "name", "holder", "collection"};
+            yield return new object[] {collection, null, "holder", "name"};
+            yield return new object[] {collection, "name", null, "holder"};
         }
 
         [Theory]
         [MemberData(nameof(CtorNullParameters))]
-        public void Ctor_NullParameter_ArgumentNullException(IBucket bucket, string name, string holder, string paramName)
+        public void Ctor_NullParameter_ArgumentNullException(ICouchbaseCollection collection, string name, string holder, string paramName)
         {
             // Act/Assert
 
-            Assert.Throws<ArgumentNullException>(paramName, () => new CouchbaseMutex(bucket, name, holder));
+            Assert.Throws<ArgumentNullException>(paramName, () => new CouchbaseMutex(collection, name, holder, NullLogger<CouchbaseMutex>.Instance));
         }
 
         #endregion


### PR DESCRIPTION
Motivation
----------
Provide support for distributed mutexes to users of the 3.x SDK.

Modifications
-------------
Upgrade to SDK 3.x. Rewrite mutexes to be based on an
ICouchbaseCollection instead of an IBucket, to use exceptions instead of
responses containing errors, and the new logging infrastructure.

Upgrade to C# 8 and enable nullable reference types.

Update unit tests, the example project, and documentation.

Results
-------
SDK 3.x compatibility.

Closes #83