### PR TITLE
Handle DocumentNotFoundException

### DIFF
--- a/src/Couchbase.Extensions.Caching/CouchbaseCache.cs
+++ b/src/Couchbase.Extensions.Caching/CouchbaseCache.cs
@@ -44,7 +44,7 @@ namespace Couchbase.Extensions.Caching
         /// </summary>
         /// <param name="key">The key to lookup the item.</param>
         /// <returns>The cache item if found, otherwise null.</returns>
-        public byte[] Get(string key) =>
+        public byte[]? Get(string key) =>
             GetAsync(key).GetAwaiter().GetResult();
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Couchbase.Extensions.Caching
         /// <param name="key">The key to lookup the item.</param>
         /// <param name="token">The <see cref="CancellationToken"/> for the operation.</param>
         /// <returns>The cache item if found, otherwise null.</returns>
-        public async Task<byte[]> GetAsync(string key, CancellationToken token = new CancellationToken())
+        public async Task<byte[]?> GetAsync(string key, CancellationToken token = new CancellationToken())
         {
             token.ThrowIfCancellationRequested();
             if (key == null)
@@ -61,10 +61,17 @@ namespace Couchbase.Extensions.Caching
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var collection = await CollectionProvider.GetCollectionAsync().ConfigureAwait(false);
-            var result = await collection.GetAsync(key, new GetOptions().Transcoder(_transcoder))
-                .ConfigureAwait(false);
-            return result.ContentAs<byte[]>();
+            try
+            {
+                var collection = await CollectionProvider.GetCollectionAsync().ConfigureAwait(false);
+                var result = await collection.GetAsync(key, new GetOptions().Transcoder(_transcoder))
+                    .ConfigureAwait(false);
+                return result.ContentAs<byte[]>();
+            }
+            catch (DocumentNotFoundException)
+            {
+                return null;
+            }
         }
 
         /// <summary>
@@ -73,7 +80,7 @@ namespace Couchbase.Extensions.Caching
         /// <param name="key">The key to lookup the item.</param>
         /// <param name="token">The <see cref="CancellationToken"/> for the operation.</param>
         /// <returns>The cache item if found, otherwise null.</returns>
-        async Task<byte[]> IDistributedCache.GetAsync(string key, CancellationToken token)
+        async Task<byte[]?> IDistributedCache.GetAsync(string key, CancellationToken token)
         {
             token.ThrowIfCancellationRequested();
             if (key == null)
@@ -173,8 +180,15 @@ namespace Couchbase.Extensions.Caching
                 throw new ArgumentNullException(nameof(key));
             }
 
-            var collection = await CollectionProvider.GetCollectionAsync().ConfigureAwait(false);
-            await collection.RemoveAsync(key).ConfigureAwait(false);
+            try
+            {
+                var collection = await CollectionProvider.GetCollectionAsync().ConfigureAwait(false);
+                await collection.RemoveAsync(key).ConfigureAwait(false);
+            }
+            catch (DocumentNotFoundException)
+            {
+                // Ignore
+            }
         }
 
         /// <inheritdoc />

--- a/tests/Couchbase.Extensions.Caching.IntegrationTests/CouchbaseCacheTests.cs
+++ b/tests/Couchbase.Extensions.Caching.IntegrationTests/CouchbaseCacheTests.cs
@@ -126,6 +126,18 @@ namespace Couchbase.Extensions.Caching.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_GetAsync_Missing()
+        {
+            var cache = GetCache();
+
+            const string key = "CouchbaseCacheTests.Test_GetAsync_Missing";
+
+            var bytes = await cache.GetAsync(key);
+
+            Assert.Null(bytes);
+        }
+
+        [Fact]
         public async Task Test_Remove()
         {
             var cache = GetCache();
@@ -173,6 +185,16 @@ namespace Couchbase.Extensions.Caching.IntegrationTests
             await cache.RemoveAsync(key);
 
             await Assert.ThrowsAsync<DocumentNotFoundException>(() => collection.GetAsync(key));
+        }
+
+        [Fact]
+        public async Task Test_RemoveAsync_Missing()
+        {
+            var cache = GetCache();
+
+            const string key = "CouchbaseCacheTests.Test_RemoveAsync_Missing";
+
+            await cache.RemoveAsync(key);
         }
 
         [Fact]

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Couchbase.Core;
+using Couchbase.Core.Exceptions.KeyValue;
+using Couchbase.KeyValue;
 using Moq;
 using Xunit;
 
@@ -49,6 +51,24 @@ namespace Couchbase.Extensions.Caching.UnitTests
         }
 
         [Fact]
+        public async Task GetAsync_DocumentNotFound_ReturnsNull()
+        {
+            var collection = new Mock<ICouchbaseCollection>();
+            collection
+                .Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<GetOptions>()))
+                .ThrowsAsync(new DocumentNotFoundException());
+
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+            provider
+                .Setup(m => m.GetCollectionAsync())
+                .ReturnsAsync(collection.Object);
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            await cache.GetAsync("key");
+        }
+
+        [Fact]
         public void Refresh_WhenKeyIsNull_ThrowArgumentNullException()
         {
             var provider = new Mock<ICouchbaseCacheCollectionProvider>();
@@ -86,6 +106,24 @@ namespace Couchbase.Extensions.Caching.UnitTests
             var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
 
             await Assert.ThrowsAsync< ArgumentNullException>(async () => await cache.RemoveAsync(null));
+        }
+
+        [Fact]
+        public async Task RemoveAsync_DocumentNotFound_ReturnsNull()
+        {
+            var collection = new Mock<ICouchbaseCollection>();
+            collection
+                .Setup(m => m.RemoveAsync(It.IsAny<string>(), It.IsAny<RemoveOptions>()))
+                .ThrowsAsync(new DocumentNotFoundException());
+
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+            provider
+                .Setup(m => m.GetCollectionAsync())
+                .ReturnsAsync(collection.Object);
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            await cache.RemoveAsync("key");
         }
 
         [Fact]


### PR DESCRIPTION
Motivation
----------
DocumentNotFoundException is not always being consistently handled per
the IDistributedCache expected behaviors.

Modifications
-------------
Return null for all cases of Get where the document is not found, and
updated nullable ref attributes to reflect the possibility.

Ignore missing documents on all cases of Remove.

Add related tests.

Results
-------
Behaviors are now consistent with expectations for IDistributedCache.

Fixes #90