### PR TITLE
Handle doc not found in typed caching extensions

### DIFF
--- a/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
+++ b/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
@@ -17,13 +17,13 @@
     <RepositoryUrl>https://github.com/couchbaselabs/Couchbase.Extensions</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
-    <LangVersion>8</LangVersion>
+    <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.2.1" />
-    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.2.0" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.2.5" />
+    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.2.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />


### PR DESCRIPTION
Motivation
----------
Previous changes to handle DocumentNotFoundException when getting from
the cache missed the static extension methods.

Modifications
-------------
Handle the DocumentNotFoundException in the static extension methods,
returning default/null on a cache miss.

Add nullable annotations indicating the potential null return value,
which required moving up to C# 9.

Results
-------
Strongly-typed gets from the cache now return null instead of throwing
an exception, correctly matching the interface spec for
IDistributedCache.