### PR TITLE
Update Couchbase.Extensions.Caching.csproj for 3.2.5

### DIFF
--- a/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
+++ b/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
@@ -7,18 +7,20 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.0.0</Version>
+    <Version>3.2.5</Version>
     <Description>A custom ASP.NET Core Middleware plugin for distributed cache using Couchbase server as the backing store. Supports both Memcached (in-memory) and Couchbase (persistent) buckets.</Description>
     <PackageTags>Couchbase;netcore;cache;session;caching;distributed;middleware;database;nosql;json</PackageTags>
-    <Copyright>Couchbase, Inc. 2020</Copyright>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <Copyright>Couchbase, Inc. 2021</Copyright>
     <PackageProjectUrl>https://github.com/couchbaselabs/Couchbase.Extensions</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/couchbaselabs/Linq2Couchbase/master/Packaging/couchbase-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/couchbaselabs/Couchbase.Extensions</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
+    <SignAssembly>true</SignAssembly>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageIcon>couchbase.png</PackageIcon>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,6 +29,13 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="couchbase.png">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Motivation
----------
Improvements for release 3.2.5 release including upgrading obsolete
csproj attributes. Note that we switching from 2.0.0 to 3.2.5 to sync
with the SDK versioning.

Modifications
-------------
 - Remove deprecated PackageIconUrl and PackageLicenseUrl
 - Add PackageIcon and PackageLicenseExpression
 - Bump version to 3.2.5