### PR TITLE
Make CouchbaseSession depend upon ICouchbaseCache

### DIFF
--- a/Couchbase.Extensions.sln
+++ b/Couchbase.Extensions.sln
@@ -54,7 +54,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Extensions.Compre
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Extensions.Session.Example", "..\temp\Couchbase.Extensions\example\Couchbase.Extensions.Session.Example\Couchbase.Extensions.Session.Example.csproj", "{2002815D-BB04-4EE7-A671-D2A8A4E0A498}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Couchbase.Extensions.Caching.Example", "example\Couchbase.Extensions.Caching.Example\Couchbase.Extensions.Caching.Example.csproj", "{02FC8C26-DD40-4944-B897-B30598F8BC58}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Extensions.Caching.Example", "example\Couchbase.Extensions.Caching.Example\Couchbase.Extensions.Caching.Example.csproj", "{02FC8C26-DD40-4944-B897-B30598F8BC58}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/example/Couchbase.Extensions.Caching.Example/Couchbase.Extensions.Caching.Example.csproj
+++ b/example/Couchbase.Extensions.Caching.Example/Couchbase.Extensions.Caching.Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Couchbase.Extensions.Caching" Version="3.3.4" />
+    <PackageReference Include="Couchbase.Extensions.Caching" Version="3.3.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/example/Couchbase.Extensions.Caching.Example/Program.cs
+++ b/example/Couchbase.Extensions.Caching.Example/Program.cs
@@ -1,3 +1,4 @@
+using Couchbase.Extensions.Caching;
 using Couchbase.Extensions.DependencyInjection;
 
 namespace Couchbase.Extensions.Caching.Example

--- a/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
+++ b/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
@@ -7,7 +7,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>3.3.4</Version>
+    <Version>3.3.5</Version>
     <Description>A custom ASP.NET Core Middleware plugin for distributed cache using Couchbase server as the backing store. Supports both Memcached (in-memory) and Couchbase (persistent) buckets.</Description>
     <PackageTags>Couchbase;netcore;cache;session;caching;distributed;middleware;database;nosql;json</PackageTags>
     <Copyright>Couchbase, Inc. 2022</Copyright>
@@ -17,15 +17,16 @@
 
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>False</SignAssembly>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageIcon>couchbase.png</PackageIcon>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <AssemblyOriginatorKeyFile>C:\keys\Couchbase.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.3.4" />
-    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.3.4" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.3.5" />
+    <PackageReference Include="Couchbase.Extensions.DependencyInjection" Version="3.3.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />

--- a/src/Couchbase.Extensions.Caching/CouchbaseCacheServiceCollectionExtensions.cs
+++ b/src/Couchbase.Extensions.Caching/CouchbaseCacheServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ namespace Couchbase.Extensions.Caching
 
             var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IDistributedCache));
             if (descriptor != null) services.Remove(descriptor);
-            services.TryAddSingleton<IDistributedCache, CouchbaseCache>();
+            services.TryAddSingleton<ICouchbaseCache, CouchbaseCache>();
 
             return services;
         }
@@ -62,9 +62,13 @@ namespace Couchbase.Extensions.Caching
             services.AddOptions();
             services.Configure(setupAction);
 
-            var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IDistributedCache));
-            if (descriptor != null) services.Remove(descriptor);
+            var distCacheDescriptor = services.FirstOrDefault(x => x.ServiceType == typeof(IDistributedCache));
+            if (distCacheDescriptor != null) services.Remove(distCacheDescriptor);
             services.TryAddSingleton<IDistributedCache, CouchbaseCache>();
+
+            var couchbaseCachedescriptor = services.FirstOrDefault(x => x.ServiceType == typeof(ICouchbaseCache));
+            if (couchbaseCachedescriptor != null) services.Remove(couchbaseCachedescriptor);
+            services.TryAddSingleton<ICouchbaseCache, CouchbaseCache>();
 
             return services;
         }

--- a/src/Couchbase.Extensions.Session/Couchbase.Extensions.Session.csproj
+++ b/src/Couchbase.Extensions.Session/Couchbase.Extensions.Session.csproj
@@ -38,4 +38,7 @@
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Couchbase.Extensions.Caching\Couchbase.Extensions.Caching.csproj" />
+  </ItemGroup>
 </Project>

--- a/src/Couchbase.Extensions.Session/Couchbase.Extensions.Session.csproj
+++ b/src/Couchbase.Extensions.Session/Couchbase.Extensions.Session.csproj
@@ -17,14 +17,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>aspnetcore;session;sessionstate;Couchbase;netcore;cache;session;caching;distributed;middleware;database;nosql;json</PackageTags>
 	<LangVersion>9</LangVersion>
-	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+	<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	<PackageIcon>couchbase.png</PackageIcon>
 	<GenerateDocumentationFile>False</GenerateDocumentationFile>
-	<SignAssembly>True</SignAssembly>
-	<Version>3.3.4</Version>
+	<SignAssembly>False</SignAssembly>
+	<Version>3.3.5</Version>
+	<AssemblyOriginatorKeyFile>C:\keys\Couchbase.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CouchbaseNetClient" Version="3.3.4" />
+    <PackageReference Include="CouchbaseNetClient" Version="3.3.5" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="5.0.17" />
     <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.2.0" />

--- a/src/Couchbase.Extensions.Session/CouchbaseSession.cs
+++ b/src/Couchbase.Extensions.Session/CouchbaseSession.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Couchbase.Core.IO.Serializers;
 using Couchbase.Core.IO.Transcoders;
+using Couchbase.Extensions.Caching;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,7 @@ namespace Couchbase.Extensions.Session
         private const int IdByteCount = 16;
         private const int KeyLengthLimit = ushort.MaxValue;
 
-        private readonly IDistributedCache _cache;
+        private readonly ICouchbaseCache _cache;
         private readonly string _sessionKey;
         private readonly TimeSpan _idleTimeout;
         private readonly TimeSpan _ioTimeout;
@@ -36,7 +37,7 @@ namespace Couchbase.Extensions.Session
         private byte[] _sessionIdBytes;
         public ITypeTranscoder Transcoder { get; set; } = new LegacyTranscoder();
 
-        public CouchbaseSession(IDistributedCache cache, string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout,
+        public CouchbaseSession(ICouchbaseCache cache, string sessionKey, TimeSpan idleTimeout, TimeSpan ioTimeout,
             Func<bool> tryEstablishSession, ILoggerFactory loggerFactory, bool isNewSessionKey)
         {
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));

--- a/src/Couchbase.Extensions.Session/CouchbaseSessionStore.cs
+++ b/src/Couchbase.Extensions.Session/CouchbaseSessionStore.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Couchbase.Extensions.Caching;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Session;
 using Microsoft.Extensions.Caching.Distributed;
@@ -12,7 +13,7 @@ namespace Couchbase.Extensions.Session
     /// <seealso cref="Microsoft.AspNetCore.Session.ISessionStore" />
     public class CouchbaseSessionStore : ISessionStore
     {
-        private readonly IDistributedCache _cache;
+        private readonly ICouchbaseCache _cache;
         private readonly ILoggerFactory _loggerFactory;
 
         /// <summary>
@@ -22,7 +23,7 @@ namespace Couchbase.Extensions.Session
         /// <param name="loggerFactory">The logger factory.</param>
         /// <exception cref="System.ArgumentNullException">
         /// </exception>
-        public CouchbaseSessionStore(IDistributedCache cache, ILoggerFactory loggerFactory)
+        public CouchbaseSessionStore(ICouchbaseCache cache, ILoggerFactory loggerFactory)
         {
             _cache = cache ?? throw new ArgumentNullException(nameof(cache));
             _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));

--- a/tests/Couchbase.Extensions.Session.UnitTests/Couchbase.Extensions.Session.UnitTests.csproj
+++ b/tests/Couchbase.Extensions.Session.UnitTests/Couchbase.Extensions.Session.UnitTests.csproj
@@ -29,7 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Couchbase.Extensions.Caching\Couchbase.Extensions.Caching.csproj" />
     <ProjectReference Include="..\..\src\Couchbase.Extensions.Session\Couchbase.Extensions.Session.csproj" />
   </ItemGroup>
 

--- a/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseCacheServiceCollectionExtensions.cs
+++ b/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseCacheServiceCollectionExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Couchbase.Extensions.Caching;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Couchbase.Extensions.Session.UnitTests
+{
+    internal static class CouchbaseCacheServiceCollectionExtensions
+    {
+        public static IServiceCollection AddDistributedCouchbaseCache(this IServiceCollection services)
+        {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+            services.AddOptions();
+
+            var descriptor = services.FirstOrDefault(x => x.ServiceType == typeof(ICouchbaseCache));
+            if (descriptor != null) services.Remove(descriptor);
+            services.AddSingleton<IDistributedCache, MemoryDistributedCache>();
+            services.TryAddSingleton<ICouchbaseCache, CouchbaseInMemoryCache>();
+
+            return services;
+        }
+    }
+}

--- a/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseDistributedSessionTests.cs
+++ b/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseDistributedSessionTests.cs
@@ -264,7 +264,7 @@ namespace Couchbase.Extensions.Session.UnitTests
         [Fact]
         public void Ctor_When_SessionKey_Is_Null_ArgumentException()
         {
-            var cache = new Mock<IDistributedCache>();
+            var cache = new Mock<ICouchbaseCache>();
             var loggerFactory = new Mock<ILoggerFactory>();
             Assert.Throws<ArgumentException>(() => new CouchbaseSession(cache.Object, null, new TimeSpan(0, 0, 10, 0), TimeSpan.Zero, () => true, loggerFactory.Object, true));
         }
@@ -272,7 +272,7 @@ namespace Couchbase.Extensions.Session.UnitTests
         [Fact]
         public void Ctor_When_TryEstablishSession_Is_Null_ArgumentNullException()
         {
-            var cache = new Mock<IDistributedCache>();
+            var cache = new Mock<ICouchbaseCache>();
             var loggerFactory = new Mock<ILoggerFactory>();
             Assert.Throws<ArgumentNullException>(() => new CouchbaseSession(cache.Object, "thekey", new TimeSpan(0, 0, 10, 0), TimeSpan.Zero, null, loggerFactory.Object, true));
         }
@@ -280,7 +280,7 @@ namespace Couchbase.Extensions.Session.UnitTests
         [Fact]
         public void Ctor_When_LoggerFactory_Is_Null_ArgumentNullException()
         {
-            var cache = new Mock<IDistributedCache>();
+            var cache = new Mock<ICouchbaseCache>();
 
             Assert.Throws<ArgumentNullException>(() => new CouchbaseSession(cache.Object, "thekey", new TimeSpan(0, 0, 10, 0), TimeSpan.Zero, () => true, null, true));
         }

--- a/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseInMemoryCache.cs
+++ b/tests/Couchbase.Extensions.Session.UnitTests/CouchbaseInMemoryCache.cs
@@ -1,0 +1,106 @@
+﻿using Couchbase.Extensions.Caching;
+using Microsoft.Extensions.Caching.Distributed;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Couchbase.Extensions.Session.UnitTests
+{
+    /// <summary>
+    /// A "fake" cache for unit testing Couchbase caching.
+    /// </summary>
+    internal class CouchbaseInMemoryCache : ICouchbaseCache
+    {
+        private readonly IDistributedCache _cache;
+
+        public CouchbaseInMemoryCache(IDistributedCache cache)
+        {
+            _cache = cache;
+        }
+        public bool DisableGet { get; set; }
+        public bool DisableSetAsync { get; set; }
+        public bool DisableRefreshAsync { get; set; }
+        public bool DelayGetAsync { get; set; }
+        public bool DelaySetAsync { get; set; }
+        public bool DelayRefreshAsync { get; set; }
+        public ICouchbaseCacheCollectionProvider CollectionProvider { get; }
+
+        public CouchbaseCacheOptions Options { get; }
+
+        public byte[] Get(string key)
+        {
+            if (DisableGet)
+            {
+                throw new InvalidOperationException();
+            }
+            return _cache.Get(key);
+        }
+
+        public Task<byte[]> GetAsync(string key, CancellationToken token = default)
+        {
+            if (DisableGet)
+            {
+                throw new InvalidOperationException();
+            }
+            if (DelayGetAsync)
+            {
+                token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
+                token.ThrowIfCancellationRequested();
+            }
+            return _cache.GetAsync(key, token);
+        }
+
+        public TimeSpan GetLifetime(DistributedCacheEntryOptions options = null)
+        {
+            return CouchbaseCacheExtensions.GetLifetime(this, options);
+        }
+
+        public void Refresh(string key)
+        {
+            _cache.Refresh(key);
+        }
+
+        public Task RefreshAsync(string key, CancellationToken token = default)
+        {
+            if (DisableRefreshAsync)
+            {
+                throw new InvalidOperationException();
+            }
+            if (DelayRefreshAsync)
+            {
+                token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
+                token.ThrowIfCancellationRequested();
+            }
+            return _cache.RefreshAsync(key, token);
+        }
+
+        public void Remove(string key)
+        {
+            _cache.Remove(key);
+        }
+
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            return _cache.RemoveAsync(key, token);
+        }
+
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+        {
+            _cache.Set(key, value, options);
+        }
+
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            if (DisableSetAsync)
+            {
+                throw new InvalidOperationException();
+            }
+            if (DelaySetAsync)
+            {
+                token.WaitHandle.WaitOne(TimeSpan.FromSeconds(10));
+                token.ThrowIfCancellationRequested();
+            }
+            return _cache.SetAsync(key, value, options, token);
+        }
+    }
+}


### PR DESCRIPTION
This change makes ICouchbaseCache the DI target for the CouchbaseSession class as opposed to IDistributedCache.