### PR TITLE
Upgrade to Snappier 1.1.3

### DIFF
--- a/src/Couchbase.Extensions.Compression.Snappier/Couchbase.Extensions.Compression.Snappier.csproj
+++ b/src/Couchbase.Extensions.Compression.Snappier/Couchbase.Extensions.Compression.Snappier.csproj
@@ -28,7 +28,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Snappier" Version="1.1.1" />
+    <PackageReference Include="Snappier" Version="1.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Includes a bugfix and an explicit .NET 8 target in Snappier.