### PR TITLE
Support for .NET hybrid cache

### DIFF
--- a/Couchbase.Extensions.sln
+++ b/Couchbase.Extensions.sln
@@ -55,6 +55,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.Config = NuGet.Config
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase", "..\couchbase-net-client\src\Couchbase\Couchbase.csproj", "{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Couchbase.Extensions.DependencyInjection", "..\couchbase-net-client\src\Couchbase.Extensions.DependencyInjection\Couchbase.Extensions.DependencyInjection.csproj", "{75845B26-4DEF-43B0-B503-1E00970CA212}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,6 +129,14 @@ Global
 		{02FC8C26-DD40-4944-B897-B30598F8BC58}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02FC8C26-DD40-4944-B897-B30598F8BC58}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02FC8C26-DD40-4944-B897-B30598F8BC58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75845B26-4DEF-43B0-B503-1E00970CA212}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75845B26-4DEF-43B0-B503-1E00970CA212}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75845B26-4DEF-43B0-B503-1E00970CA212}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75845B26-4DEF-43B0-B503-1E00970CA212}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -146,6 +158,8 @@ Global
 		{5AA07C99-EC7E-442D-A3EE-B8A373E0C278} = {727F95F9-8FD9-423C-ACC6-B23E0D6CCC4C}
 		{2002815D-BB04-4EE7-A671-D2A8A4E0A498} = {58E7557B-D434-402A-9B6B-0DBE59E8DF3B}
 		{02FC8C26-DD40-4944-B897-B30598F8BC58} = {58E7557B-D434-402A-9B6B-0DBE59E8DF3B}
+		{EEDA3DFA-A2D5-4CFF-969A-C2D7736953DE} = {EC47DFB9-AB39-41F8-BD7C-7B25BBCDEBD1}
+		{75845B26-4DEF-43B0-B503-1E00970CA212} = {EC47DFB9-AB39-41F8-BD7C-7B25BBCDEBD1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BBE581CF-99BB-42AD-A7C8-59FF4B45DB55}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,6 +18,8 @@
 
     <SignAssembly>False</SignAssembly>
     <AssemblyOriginatorKeyFile>C:\keys\Couchbase.snk</AssemblyOriginatorKeyFile>
+
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,12 +4,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="CouchbaseNetClient" Version="3.5.2" />
-    <PackageVersion Include="Couchbase.Extensions.DependencyInjection" Version="3.5.2" />
+    <PackageVersion Include="CouchbaseNetClient" Version="3.6.5" />
+    <PackageVersion Include="Couchbase.Extensions.DependencyInjection" Version="3.6.5" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="8.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Snappier" Version="1.1.6" />
     <PackageVersion Include="System.Reactive" Version="5.0.0" />
   </ItemGroup>
@@ -19,11 +19,12 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="fm.Extensions.Logging.Testing" Version="5.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="9.1.0-preview.1.25064.3" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.6.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />

--- a/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
+++ b/src/Couchbase.Extensions.Caching/Couchbase.Extensions.Caching.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="CouchbaseNetClient" />
     <PackageReference Include="Couchbase.Extensions.DependencyInjection" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" /> <!-- Pull in the upgraded version with IBufferDistributedCache -->
   </ItemGroup>
 
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">

--- a/src/Couchbase.Extensions.Caching/CouchbaseCacheSerializerFactory.cs
+++ b/src/Couchbase.Extensions.Caching/CouchbaseCacheSerializerFactory.cs
@@ -1,0 +1,91 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Extensions.Caching.Internal;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Couchbase.Extensions.Caching
+{
+    /// <summary>
+    /// Constructs <see cref="IHybridCacheSerializer{T}"/> instances based upon the configured type serializer
+    /// from a Couchbase collection. The type serializer must implement <see cref="IBufferedTypeSerializer"/>.
+    /// Only constructs serializers for types that the inner serializer can handle.
+    /// </summary>
+    /// <remarks>
+    /// Most Couchbase serializers will at least try to serialize all types, so when this factory is registered
+    /// any factories registered after it will not be used. However, some serializers, such as the System.Text.Json
+    /// serializer built from a JsonSerializerContext, are smarter and will only serialize types that they know about.
+    /// </remarks>
+    public sealed class CouchbaseCacheSerializerFactory : IHybridCacheSerializerFactory
+    {
+        // Optionally used to acquire to inner serializer after bootstrapping.
+        private readonly ICouchbaseCacheCollectionProvider? _collectionProvider;
+
+        private int _initialized;
+        private IBufferedTypeSerializer? _innerSerializer;
+
+        /// <summary>
+        /// Constructs a new <see cref="CouchbaseCacheSerializerFactory"/> that acquires the inner serializer
+        /// from a Couchbase collection's configuration.
+        /// </summary>
+        /// <param name="collectionProvider">The Couchbase collection.</param>
+        public CouchbaseCacheSerializerFactory(
+            ICouchbaseCacheCollectionProvider collectionProvider)
+        {
+            _collectionProvider = collectionProvider;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="CouchbaseCacheSerializerFactory"/>.
+        /// </summary>
+        /// <param name="innerSerializer">The inner Couchbase serializer.</param>
+        public CouchbaseCacheSerializerFactory(IBufferedTypeSerializer innerSerializer)
+        {
+            _innerSerializer = innerSerializer;
+            _initialized = 1;
+        }
+
+        /// <inheritdoc />
+        public bool TryCreateSerializer<T>([NotNullWhen(true)] out IHybridCacheSerializer<T>? serializer)
+        {
+            var innerSerializer = GetInnerSerializer();
+
+            if (innerSerializer is null || !innerSerializer.CanSerialize(typeof(T)))
+            {
+                serializer = null;
+                return false;
+            }
+
+            serializer = new CouchbaseHybridCacheSerializer<T>(innerSerializer);
+            return true;
+        }
+
+        private IBufferedTypeSerializer? GetInnerSerializer()
+        {
+            if (Volatile.Read(ref _initialized) > 0)
+            {
+                return Volatile.Read(ref _innerSerializer);
+            }
+
+            // The need for GetAwaiter().GetResult() is unfortunate but necessary because Couchbase.Extensions.DI
+            // doesn't currently have a method to get to the ITypeSerializer until after aysnc bootstrapping.
+            var result = Interlocked.CompareExchange(ref _innerSerializer, GetFromCollectionProvider().GetAwaiter().GetResult(), null)
+                ?? _innerSerializer;
+            Volatile.Write(ref _initialized, 1);
+
+            return result;
+
+            async Task<IBufferedTypeSerializer?> GetFromCollectionProvider()
+            {
+                Debug.Assert(_collectionProvider is not null);
+
+                var collection = await _collectionProvider.GetCollectionAsync().ConfigureAwait(false);
+                var serializer = collection.Scope.Bucket.Cluster.ClusterServices.GetRequiredService<ITypeSerializer>();
+                return serializer as IBufferedTypeSerializer;
+            }
+        }
+    }
+}

--- a/src/Couchbase.Extensions.Caching/Internal/CacheBuffer.cs
+++ b/src/Couchbase.Extensions.Caching/Internal/CacheBuffer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Couchbase.Extensions.Caching.Internal
+{
+    /// <summary>
+    /// Wrapper used for swapping buffers through the <see cref="CacheTranscoder"/>. It is used
+    /// instead of directly using <see cref="ReadOnlyMemory{T}"/> to ensure there can be no confusion
+    /// with behaviors in the transcoder being wrapped by the <see cref="CacheTranscoder"/>.
+    /// </summary>
+    internal readonly struct CacheBuffer(ReadOnlyMemory<byte> data)
+    {
+        /// <summary>
+        /// Data buffer from the operation. Only valid until the operation response is disposed.
+        /// </summary>
+        public ReadOnlyMemory<byte> Data { get; } = data;
+    }
+}

--- a/src/Couchbase.Extensions.Caching/Internal/CouchbaseHybridCacheSerializer.cs
+++ b/src/Couchbase.Extensions.Caching/Internal/CouchbaseHybridCacheSerializer.cs
@@ -1,0 +1,20 @@
+﻿using System.Buffers;
+using Couchbase.Core.IO.Serializers;
+using Microsoft.Extensions.Caching.Hybrid;
+
+namespace Couchbase.Extensions.Caching.Internal
+{
+    /// <summary>
+    /// Wraps an <see cref="IBufferedTypeSerializer"/> in a <see cref="IHybridCacheSerializer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">Type to serializer or deserialize.</typeparam>
+    /// <param name="serializer">The inner <see cref="IBufferedTypeSerializer"/>.</param>
+    internal sealed class CouchbaseHybridCacheSerializer<T>(IBufferedTypeSerializer serializer) : IHybridCacheSerializer<T>
+    {
+        /// <inheritdoc />
+        public T Deserialize(ReadOnlySequence<byte> source) => serializer.Deserialize<T>(source)!;
+
+        /// <inheritdoc />
+        public void Serialize(T value, IBufferWriter<byte> target) => serializer.Serialize(target, value);
+    }
+}

--- a/tests/Couchbase.Extensions.Caching.IntegrationTests/Couchbase.Extensions.Caching.IntegrationTests.csproj
+++ b/tests/Couchbase.Extensions.Caching.IntegrationTests/Couchbase.Extensions.Caching.IntegrationTests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />

--- a/tests/Couchbase.Extensions.Caching.IntegrationTests/HybridCacheTests.cs
+++ b/tests/Couchbase.Extensions.Caching.IntegrationTests/HybridCacheTests.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Couchbase.Extensions.Caching.Internal;
+using Couchbase.KeyValue;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Couchbase.Extensions.Caching.IntegrationTests
+{
+    public class HybridCacheTests : IClassFixture<ClusterFixture>
+    {
+        private readonly ClusterFixture _fixture;
+
+        public HybridCacheTests(ClusterFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        [Fact]
+        public async Task Test_SetAndGetAsync()
+        {
+            var cache = GetCache();
+
+            const string key = $"HybridCacheTests.{nameof(Test_SetAndGetAsync)}";
+            var poco = new Poco {Name = "poco1", Age = 12};
+
+            await cache.RemoveAsync(key);
+            await cache.SetAsync(key, poco, new HybridCacheEntryOptions
+            {
+                Flags = HybridCacheEntryFlags.DisableLocalCache
+            });
+            var result = await cache.GetOrCreateAsync(key, _ => ValueTask.FromResult(new Poco() { Name = "foo" }), new HybridCacheEntryOptions
+            {
+                Flags = HybridCacheEntryFlags.DisableLocalCache
+            });
+
+            Assert.Equal(poco.Name, result.Name);
+        }
+
+        [Fact]
+        public async Task Test_GetAsync_Missing()
+        {
+            var cache = GetCache();
+
+            const string key = $"HybridCacheTests.{nameof(Test_GetAsync_Missing)}";
+
+            var result = await cache.GetOrCreateAsync(key, _ => ValueTask.FromResult(new Poco() { Name = "foo" }), new HybridCacheEntryOptions
+            {
+                Flags = HybridCacheEntryFlags.DisableLocalCache,
+                Expiration = TimeSpan.FromSeconds(1)
+            });
+
+            Assert.Equal("foo", result.Name);
+        }
+
+        [Fact]
+        public async Task Test_RemoveAsync()
+        {
+            var cache = GetCache();
+
+            const string key = $"HybridCacheTests.{nameof(Test_RemoveAsync)}";
+
+            await cache.SetAsync(key, new Poco());
+            await cache.RemoveAsync(key);
+            var result = await cache.GetOrCreateAsync(key, _ => ValueTask.FromResult<Poco>(null), new HybridCacheEntryOptions()
+            {
+                Flags = HybridCacheEntryFlags.DisableLocalCache,
+                Expiration = TimeSpan.FromSeconds(1)
+            });
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Test_RemoveAsync_Missing()
+        {
+            var cache = GetCache();
+
+            const string key = $"HybridCacheTests.{nameof(Test_RemoveAsync)}";
+
+            await cache.RemoveAsync(key);
+        }
+
+        private HybridCache GetCache()
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<ICouchbaseCacheBucketProvider>(_fixture);
+            services.AddSingleton<ICouchbaseCacheCollectionProvider>(_fixture);
+            services.AddDistributedCouchbaseCache();
+
+#pragma warning disable EXTEXP0018 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+            services
+                .AddHybridCache(options =>
+                {
+                    options.MaximumKeyLength = 250; // Maximum Couchbase key size
+                    options.MaximumPayloadBytes = 20 * 1024 * 1024; // Maximum 20MB Couchbase document size
+                    options.DisableCompression = true; // Prefer Snappy compression built into the Couchbase SDK
+                })
+                .AddSerializerFactory<CouchbaseCacheSerializerFactory>();
+#pragma warning restore EXTEXP0018 // Type is for evaluation purposes only and is subject to change or removal in future updates.
+
+            return services.BuildServiceProvider(new ServiceProviderOptions()
+            {
+                ValidateOnBuild = true,
+                ValidateScopes = true
+            })
+                .GetRequiredService<HybridCache>();
+        }
+
+        public class Poco
+        {
+            public string Name { get; set; }
+
+            public int Age { get; set; }
+
+            public override string ToString()
+            {
+                return string.Concat(Name, "-", Age);
+            }
+        }
+    }
+}

--- a/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
+++ b/tests/Couchbase.Extensions.Caching.UnitTests/CouchbaseCacheTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Couchbase.Core.Exceptions.KeyValue;
@@ -184,5 +185,135 @@ namespace Couchbase.Extensions.Caching.UnitTests
 
             await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.SetAsync(null, Array.Empty<byte>(), null));
         }
+
+        #region TryGet
+
+        [Fact]
+        public async Task TryGetAsync_WhenKeyIsNull_ThrowArgumentNullException()
+        {
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            var writer = new ArrayBufferWriter<byte>();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await cache.TryGetAsync(null, writer));
+        }
+
+        [Fact]
+        public async Task TryGetAsync_DocumentNotFound_ReturnsFalse()
+        {
+            var collection = new Mock<ICouchbaseCollection>();
+            collection
+                .Setup(m => m.LookupInAsync(It.IsAny<string>(), It.IsAny<IEnumerable<LookupInSpec>>(), It.IsAny<LookupInOptions>()))
+                .ThrowsAsync(new DocumentNotFoundException());
+            collection
+                .Setup(m => m.Scope.Bucket.Cluster.ClusterServices.GetService(typeof(ITypeTranscoder)))
+                .Returns(new JsonTranscoder());
+
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+            provider
+                .Setup(m => m.GetCollectionAsync())
+                .ReturnsAsync(collection.Object);
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            var writer = new ArrayBufferWriter<byte>();
+
+            var result = await cache.TryGetAsync("key", writer);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task TryGetAsync_DocumentFound_ReturnsTrueAndWrites()
+        {
+            var lookupResult = new Mock<ILookupInResult>();
+            lookupResult
+                .Setup(m => m.Exists(0))
+                .Returns(true);
+            lookupResult
+                .Setup(m => m.Exists(1))
+                .Returns(true);
+            lookupResult
+                .Setup(m => m.ContentAs<CacheBuffer>(0))
+                .Returns((int _) => new CacheBuffer(TestBytes.ToArray()));
+            lookupResult
+                .Setup(m => m.ContentAs<CacheMetadata>(1))
+                .Returns((int _) => new CacheMetadata { AbsoluteExpiration = DateTime.UtcNow.AddHours(1) });
+
+            var collection = new Mock<ICouchbaseCollection>();
+            collection
+                .Setup(m => m.LookupInAsync(It.IsAny<string>(), It.IsAny<IEnumerable<LookupInSpec>>(), It.IsAny<LookupInOptions>()))
+                .ReturnsAsync(lookupResult.Object);
+            collection
+                .Setup(m => m.Scope.Bucket.Cluster.ClusterServices.GetService(typeof(ITypeTranscoder)))
+                .Returns(new JsonTranscoder());
+
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+            provider
+                .Setup(m => m.GetCollectionAsync())
+                .ReturnsAsync(collection.Object);
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            var writer = new ArrayBufferWriter<byte>();
+
+            var result = await cache.TryGetAsync("key", writer);
+
+            Assert.True(result);
+            Assert.True(writer.WrittenSpan.SequenceEqual(TestBytes), "Written data does not match.");
+        }
+
+        [Fact]
+        public async Task TryGetAsync_DocumentFoundWithSlidingExpiration_Touches()
+        {
+            var lookupResult = new Mock<ILookupInResult>();
+            lookupResult
+                .Setup(m => m.Exists(0))
+                .Returns(true);
+            lookupResult
+                .Setup(m => m.Exists(1))
+                .Returns(true);
+            lookupResult
+                .Setup(m => m.ContentAs<CacheBuffer>(0))
+                .Returns((int _) => new CacheBuffer(TestBytes.ToArray()));
+            lookupResult
+                .Setup(m => m.ContentAs<CacheMetadata>(1))
+                .Returns((int _) => new CacheMetadata { SlidingExpiration = TimeSpan.FromMinutes(1) });
+
+            var collection = new Mock<ICouchbaseCollection>();
+            collection
+                .Setup(m => m.LookupInAsync(It.IsAny<string>(), It.IsAny<IEnumerable<LookupInSpec>>(), It.IsAny<LookupInOptions>()))
+                .ReturnsAsync(lookupResult.Object);
+            collection
+                .Setup(m => m.TouchAsync(It.IsAny<string>(), It.IsAny<TimeSpan>(), It.IsAny<TouchOptions>()))
+                .Returns(Task.CompletedTask);
+            collection
+                .Setup(m => m.Scope.Bucket.Cluster.ClusterServices.GetService(typeof(ITypeTranscoder)))
+                .Returns(new JsonTranscoder());
+
+            var provider = new Mock<ICouchbaseCacheCollectionProvider>();
+            provider
+                .Setup(m => m.GetCollectionAsync())
+                .ReturnsAsync(collection.Object);
+
+            var cache = new CouchbaseCache(provider.Object, new CouchbaseCacheOptions());
+
+            var writer = new ArrayBufferWriter<byte>();
+
+            var result = await cache.TryGetAsync("key", writer);
+
+            Assert.True(result);
+            collection.Verify(m => m.TouchAsync("key", TimeSpan.FromMinutes(1), It.IsAny<TouchOptions>()), Times.Once);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static ReadOnlySpan<byte> TestBytes => [0, 1, 2, 3, 4, 5, 6];
+
+        #endregion
     }
 }


### PR DESCRIPTION
Motivation
----------
ASP.NET Core 9 has added the concept of a hybrid cache. This is a mixed memory and distributed cache, which uses memory as the L1 cache and efficiently uses the distributed cache as the L2 cache. While the specific implementation is in preview, the abstractions supporting it are available now. By adding `IBufferDistributedCache` interface and an implementation of `IHybridCacheSerializerFactory` we'll be compatible.

Modifications
-------------
- Upgrade to Couchbase SDK 3.6.5 to get support for deserializing from `ReadOnlySequence<T>` and serializing to `IBufferWriter<byte>` via the new `IBufferedTypeSerializer` interface.
- Upgrade to `Microsoft.Extensions.Caching.Abstractions` 9.0.1. Note that this is backward compatible to .NET 6.
- Implement an `IHybridCacheSerializer<T>` wrapper for `IBufferedTypeSerializer` and expose it via a new public type implementing `IHybridCacheSerializerFactory`.
- Add `IBufferDistributedCache` to `CouchbaseCache`.
- Add support for the new serialization and deserialization types to `CacheTranscoder`.
- Add integration and unit tests.

Results
-------
Consumers who want to use the preview support may do so, and we'll be immediately ready when the final `Microsoft.Extensions.Caching.Hybrid` package is released.