### PR TITLE
Always use System.Text.Json for serializing mutexes

### DIFF
--- a/src/Couchbase.Extensions.Locks/Internal/LockDocument.cs
+++ b/src/Couchbase.Extensions.Locks/Internal/LockDocument.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using Couchbase.Core.IO.Serializers;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace Couchbase.Extensions.Locks.Internal
 {
@@ -8,14 +7,11 @@ namespace Couchbase.Extensions.Locks.Internal
     {
         private const string LockPrefix = "__lock_";
 
-        [JsonProperty(PropertyName = "name")]
         public string? Name { get; set; }
 
-        [JsonProperty(PropertyName = "holder")]
         public string? Holder { get; set; }
 
-        [JsonConverter(typeof(UnixMillisecondsConverter))]
-        [JsonProperty(PropertyName = "requestedDateTime")]
+        [JsonConverter(typeof(UnixMillisecondsJsonConverter))]
         public DateTime RequestedDateTime { get; set; }
 
         public static string GetKey(string name)

--- a/src/Couchbase.Extensions.Locks/Internal/LockSerializerContext.cs
+++ b/src/Couchbase.Extensions.Locks/Internal/LockSerializerContext.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Couchbase.Extensions.Locks.Internal
+{
+    [JsonSourceGenerationOptions(
+        PropertyNameCaseInsensitive = true, // backward compatibility
+        PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+    [JsonSerializable(typeof(LockDocument))]
+    internal sealed partial class LockSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/Couchbase.Extensions.Locks/Internal/UnixMillisecondsJsonConverter.cs
+++ b/src/Couchbase.Extensions.Locks/Internal/UnixMillisecondsJsonConverter.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Couchbase.Extensions.Locks.Internal
+{
+    /// <summary>
+    /// System.Text.Json converter that represents DateTime as milliseconds since the Unix epoch.
+    /// </summary>
+    internal class UnixMillisecondsJsonConverter : JsonConverter<DateTime>
+    {
+        private static readonly DateTime UnixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                var dbl = reader.GetDouble();
+                var ticks = (long)(dbl * TimeSpan.TicksPerMillisecond);
+                return new DateTime(UnixEpoch.Ticks + ticks, DateTimeKind.Utc);
+            }
+            else if (reader.TokenType == JsonTokenType.String)
+            {
+                // Backward compatibility for consumers using System.Text.Json when this library was designed
+                // for Newtonsoft.Json, in which case ISO8601 strings were stored.
+
+                return reader.GetDateTime();
+            }
+
+            throw new JsonException("Expected number or string for DateTime value.");
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            if (value.Kind == DateTimeKind.Local)
+            {
+                value = value.ToUniversalTime();
+            }
+
+            var unixMilliseconds = (value - UnixEpoch).TotalMilliseconds;
+            writer.WriteNumberValue(unixMilliseconds);
+        }
+    }
+}
+
+
+/* ************************************************************
+ *
+ *    @author Couchbase <info@couchbase.com>
+ *    @copyright 2021 Couchbase, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ * ************************************************************/

--- a/tests/Couchbase.Extensions.Locks.UnitTests/Internal/TranscoderTests.cs
+++ b/tests/Couchbase.Extensions.Locks.UnitTests/Internal/TranscoderTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Text;
+using System.Text.Json;
+using Couchbase.Core.IO.Serializers;
+using Couchbase.Extensions.Locks.Internal;
+using Xunit;
+
+namespace Couchbase.Extensions.Locks.UnitTests.Internal
+{
+    public class TranscoderTests
+    {
+        [Fact]
+        public void LegacyNewtonsoft_DeserializeSuccess()
+        {
+            // Arrange
+
+            var legacyLockDocument = new LegacyLockDocument()
+            {
+                Name = "name",
+                Holder = "holder",
+                RequestedDateTime = DateTime.UtcNow
+            };
+
+            var json = Encoding.UTF8.GetBytes(
+                Newtonsoft.Json.JsonConvert.SerializeObject(legacyLockDocument));
+
+            // Act
+
+            var deserialized = CouchbaseMutex.Transcoder.Serializer.Deserialize<LockDocument>(json);
+
+            // Assert
+
+            Assert.Equal(legacyLockDocument.Name, deserialized.Name);
+            Assert.Equal(legacyLockDocument.Holder, deserialized.Holder);
+            Assert.InRange(legacyLockDocument.RequestedDateTime.Ticks - deserialized.RequestedDateTime.Ticks,
+                -1000, 1000);
+        }
+
+        [Fact]
+        public void LegacySystemTextJson_DeserializeSuccess()
+        {
+            // Arrange
+
+            var legacyLockDocument = new LegacyLockDocument()
+            {
+                Name = "name",
+                Holder = "holder",
+                RequestedDateTime = DateTime.UtcNow
+            };
+
+            var json = Encoding.UTF8.GetBytes(
+                JsonSerializer.Serialize(legacyLockDocument));
+
+            // Act
+
+            var deserialized = CouchbaseMutex.Transcoder.Serializer.Deserialize<LockDocument>(json);
+
+            // Assert
+
+            Assert.Equal(legacyLockDocument.Name, deserialized.Name);
+            Assert.Equal(legacyLockDocument.Holder, deserialized.Holder);
+            Assert.InRange(legacyLockDocument.RequestedDateTime.Ticks - deserialized.RequestedDateTime.Ticks,
+                -1000, 1000);
+        }
+
+        private class LegacyLockDocument
+        {
+            [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+            public string Name { get; set; }
+
+            [Newtonsoft.Json.JsonProperty(PropertyName = "holder")]
+            public string Holder { get; set; }
+
+            [Newtonsoft.Json.JsonConverter(typeof(UnixMillisecondsConverter))]
+            [Newtonsoft.Json.JsonProperty(PropertyName = "requestedDateTime")]
+            public DateTime RequestedDateTime { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
In some System.Text.Json configurations of the Couchbase SDK, mutex documents are not serialized correctly. Additionally, if using a serializer built from a JsonSerializerContext they will fail because the lock document isn't included in the context. Since the class for the document is internal, it isn't possible for the consumer to include it in their JsonSerializerContext.

Modifications
-------------
Always use a JsonTranscoder that uses an internal System.Text.Json serializer built around an internal JsonSerializerContext for all mutex documents.

Results
-------
- Consistent behavior regardless of the serializer selected in the Couchbase SDK or its configuration
- This should also offer higher performance than the Newtonsoft serializer or reflection-based System.Text.Json serializer

Fixes #118